### PR TITLE
decoding Unicode is not supported Error Resolved

### DIFF
--- a/tablereader/__init__.py
+++ b/tablereader/__init__.py
@@ -70,7 +70,7 @@ class XLReader(object):
         for element in row:
             if isinstance(element, float):
                 element = str(element)
-            newrow.append(six_u(element))
+            newrow.append(six_u(element) if not isinstance(element, unicode) else element)
         return newrow
 
 


### PR DESCRIPTION
Resolved Type Error while decoding, Simple rule; do not encode if already a unicode.

TypeError: decoding Unicode is not supported
